### PR TITLE
Adds support for both API URIs

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -25,10 +25,20 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <!--
+      If you are on the EU server, please uncommented that tag and comment
+      out the US tag.
+    -->
     <script
       type="module"
-      src="https://api.embeddable.com/js/v1/">
+      src="https://api.us.embeddable.com/js/v1/">
     </script>
+    <!--
+    <script
+      type="module"
+      src="https://api.eu.embeddable.com/js/v1/">
+    </script>
+    -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,8 @@ const SECURITY_CONTEXT = {
     userId: '9sZSJ9LHsiYXR0cmlidX'
 };
 const USER_KEY = 'some-user@domain.com';
-
+const BASE_URL = 'https://api.us.embeddable.com'; // US
+// const BASE_URL = 'https://api.eu.embeddable.com'; // EU
 
 const app = express();
 
@@ -17,7 +18,7 @@ const app = express();
 app.use(express.static(path.resolve(__dirname, '../client/build')));
 
 app.get('/embeddables', async (req, res) => {
-    const response = await fetch(`https://api.embeddable.com/api/v1/embeddables`, {
+    const response = await fetch(`${BASE_URL}/api/v1/embeddables`, {
         method: 'GET',
         headers: {
             'Content-Type': 'application/json',
@@ -33,7 +34,7 @@ app.get('/embeddables', async (req, res) => {
 
 app.get('/token', async (req, res) => {
 	console.log(req)
-	const response = await fetch(`https://api.embeddable.com/api/v1/security-token`, {
+	const response = await fetch(`${BASE_URL}/api/v1/security-token`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/src/react-test.html
+++ b/src/react-test.html
@@ -3,7 +3,12 @@
   <head>
     <title>Embedabble</title>
     <meta charset="utf-8" />
-    <script type="module" src="https://api.embeddable.com/js/v1/"></script>
+    <!--
+      If you are on the EU server, please uncomment that line and
+      comment out the US line.
+     -->
+    <script type="module" src="https://api.us.embeddable.com/js/v1/"></script>
+    <!-- <script type="module" src="https://api.eu.embeddable.com/js/v1/"></script> -->
     <script
       src="https://unpkg.com/react@18/umd/react.development.js"
       crossorigin

--- a/src/test.js
+++ b/src/test.js
@@ -10,12 +10,13 @@ const SECURITY_CONTEXT = {
     userId: '9sZSJ9LHsiYXR0cmlidX'
 };
 const USER_KEY = 'some-user@domain.com';
-
+const BASE_URL = 'https://api.us.embeddable.com'; // US
+// const BASE_URL = 'https://api.eu.embeddable.com'; // EU
 
 async function handler(req, res) {
     console.log('Fetching token...')
 
-    const response = await fetch(`https://api.embeddable.com/api/v1/security-token`, {
+    const response = await fetch(`${BASE_URL}/api/v1/security-token`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -57,7 +58,7 @@ async function handler(req, res) {
           <meta charset="utf-8" />
           <script
             type="module"
-            src="https://api.embeddable.com/js/v1/"
+            src="${BASE_URL}/js/v1/"
           ></script>
         </head>
         <body>


### PR DESCRIPTION
**Description**

Converts this example repo to use `BASE_URL` (or the HTML equivalent: commenting/uncommenting script tags) in order to use the US/EU API servers.

**Acceptance Criteria**

Anywhere there's an API Call, it should be possible to switch it from US to EU depending on what's commented / uncommented.